### PR TITLE
Don't subtype `ViewEngine` to `DenseVector`

### DIFF
--- a/src/MoYe.jl
+++ b/src/MoYe.jl
@@ -16,7 +16,7 @@ include("int_tuple.jl")
 include("stride.jl")
 include("layout.jl")
 include("print.jl")
-include("container/engine.jl")
+include("engine.jl")
 
 include("array.jl")
 include("broadcast.jl")

--- a/src/algorithm/array_algorithms.jl
+++ b/src/algorithm/array_algorithms.jl
@@ -142,8 +142,8 @@ end
     b = ManualMemory.preserve_buffer(x)
     vb = ViewEngine(engine(x))
     GC.@preserve b begin
-        @loopinfo unroll  for i in 1:length(vb)
-            @inbounds vb[i] = val
+        @loopinfo unroll  for i in 1:length(b)
+            vb[i] = val
         end
     end
     return x
@@ -154,8 +154,8 @@ end
     vx = ViewEngine(engine(x))
     GC.@preserve b begin
         tmp = zero(T)
-        @loopinfo unroll  for i in 1:length(vx)
-            @inbounds tmp += vx[i]
+        @loopinfo unroll for i in 1:length(x)
+            tmp += vx[i]
         end
         return tmp
     end

--- a/src/engine.jl
+++ b/src/engine.jl
@@ -1,34 +1,26 @@
-abstract type Engine{T} <: DenseVector{T} end
-
-@inline Base.IndexStyle(::Type{<:Engine}) = IndexLinear()
-@inline Base.elsize(::Engine{T}) where {T} = sizeof(T)
-
 """
-    ViewEngine{T, P} <: Engine{T} <: DenseVector{T}
+    ViewEngine{T, P}
 
-A non-owning view of a memory buffer. `P` is the type of the pointer.
+A wrapper of a pointer. `P` is the type of the pointer.
 """
-struct ViewEngine{T, P} <: Engine{T}
+struct ViewEngine{T, P}
     ptr::P
-    len::Int
 end
 
-@inline function ViewEngine(ptr::Ptr{T}, len::Int) where {T}
-    return ViewEngine{T, typeof(ptr)}(ptr, len)
+@inline function ViewEngine(ptr::Ptr{T}) where {T}
+    return ViewEngine{T, typeof(ptr)}(ptr)
 end
-@inline function ViewEngine(ptr::LLVMPtr{T, AS}, len::Int) where {T, AS}
-    return ViewEngine{T, typeof(ptr)}(ptr, len)
-end
-@inline function ViewEngine(ptr::Ptr{T}, len::StaticInt{N}) where {T, N}
-    return ViewEngine{T, typeof(ptr)}(ptr, N)
-end
-@inline function ViewEngine(ptr::LLVMPtr{T, AS}, len::StaticInt{N}) where {T, N, AS}
-    return ViewEngine{T, typeof(ptr)}(ptr, N)
+@inline function ViewEngine(ptr::LLVMPtr{T, AS}) where {T, AS}
+    return ViewEngine{T, typeof(ptr)}(ptr)
 end
 
 @inline function ViewEngine(A::AbstractArray)
-    p = LayoutPointers.memory_reference(A)[1] # not sure what this does
-    return ViewEngine(p, length(A))
+    p = LayoutPointers.memory_reference(A)[1]
+    return ViewEngine(p)
+end
+
+@inline function ViewEngine(A::ViewEngine)
+    return A
 end
 
 @inline Base.pointer(A::ViewEngine) = getfield(A, :ptr)
@@ -39,16 +31,11 @@ end
     return Base.unsafe_convert(p, pointer(A))
 end
 
-@inline Base.size(A::ViewEngine) = tuple(Static.dynamic(getfield(A, :len)))
-@inline Base.length(A::ViewEngine) = Static.dynamic(getfield(A, :len))
-
 @inline function Base.getindex(A::ViewEngine{T}, i::Integer) where {T}
-    @boundscheck checkbounds(A, i)
     return unsafe_load(pointer(A), i)
 end
 
 @inline function Base.setindex!(A::ViewEngine{T}, val, i::Integer) where {T}
-    @boundscheck checkbounds(A, i)
     unsafe_store!(pointer(A), val, i)
     return val
 end
@@ -56,23 +43,11 @@ end
 @inline ManualMemory.preserve_buffer(::ViewEngine) = nothing
 
 """
-    ArrayEngine{T, L} <: Engine{T} <: DenseVector{T}
+    ArrayEngine{T, L} <: DenseVector{T}
 
-A owning vector of type `T` with length `L`. It is stack-allocated and mutable. It should
-behaves like a `StaticStrideArray` with from `StrideArrays` package.
-
-## Examples
-
-```julia
-function test_alloc()
-    x = ArrayEngine{Float32}(one, static(10))
-    @gc_preserve sum(x)
-end
-
-@test @allocated(test_alloc()) == 0
-```
+A owning vector of type `T` with static length `L`.
 """
-mutable struct ArrayEngine{T, L} <: Engine{T}
+mutable struct ArrayEngine{T, L} <: DenseVector{T}
     data::NTuple{L, T}
     @inline ArrayEngine{T, L}(::UndefInitializer) where {T, L} = new{T, L}()
     @inline function ArrayEngine{T}(::UndefInitializer, ::StaticInt{L}) where {T, L}
@@ -95,10 +70,10 @@ end
     return ArrayEngine{T}(undef, static(length(A)))
 end
 
-@inline function ArrayEngine{T}(f::Function, ::StaticInt{L}) where {T, L}
+@inline function ArrayEngine{T}(f::Function, ::StaticInt{L}) where {T, L} # not very useful
     A = ArrayEngine{T, L}(undef)
-    @inbounds for i in eachindex(A)
-        A[i] = f(i)
+    @loopinfo unroll for i in eachindex(A)
+        @inbounds A[i] = f(i)
     end
     return A
 end
@@ -107,16 +82,17 @@ end
     return ManualMemory.preserve_buffer(getfield(A, :data))
 end
 
-@inline StrideArraysCore.maybe_ptr_array(A::ArrayEngine{T, L}) where {T, L} = ViewEngine(pointer(A), L)
-
-Base.@propagate_inbounds function Base.getindex(A::ArrayEngine,
-                                                i::Union{Integer, StaticInt})
+@inline function Base.getindex(A::ArrayEngine, i::Union{Integer, StaticInt})
+    @boundscheck checkbounds(A, i)
     b = ManualMemory.preserve_buffer(A)
     GC.@preserve b begin ViewEngine(A)[i] end
 end
 
-Base.@propagate_inbounds function Base.setindex!(A::ArrayEngine, val,
+@inline function Base.setindex!(A::ArrayEngine, val,
                                                  i::Union{Integer, StaticInt})
+    @boundscheck checkbounds(A, i)
     b = ManualMemory.preserve_buffer(A)
     GC.@preserve b begin ViewEngine(A)[i] = val end
 end
+
+const Engine{T} = Union{ViewEngine{T}, ArrayEngine{T}}

--- a/src/engine.jl
+++ b/src/engine.jl
@@ -45,7 +45,25 @@ end
 """
     ArrayEngine{T, L} <: DenseVector{T}
 
-A owning vector of type `T` with static length `L`.
+A owning and mutable vector of type `T` with static length `L`.
+
+## Examples
+
+```julia
+julia> x = ArrayEngine{Float32}(undef, static(3))
+3-element ArrayEngine{Float32, 3}:
+ -9.8271385f-36
+  7.57f-43
+ -9.8271385f-36
+
+julia> x[1] = 10f0
+10.0f0
+
+julia> x
+3-element ArrayEngine{Float32, 3}:
+ 10.0
+  7.57f-43
+ -9.8271385f-36
 """
 mutable struct ArrayEngine{T, L} <: DenseVector{T}
     data::NTuple{L, T}

--- a/test/array.jl
+++ b/test/array.jl
@@ -80,6 +80,7 @@ end
 
 @testset "Recast" begin
     x = MoYeArray{Float32}(undef, static((4, 3)))
+    zeros!(x)
     @testset "Upcast" begin
         x2 = recast(Float64, x)
         @test x2 isa MoYeArray{Float64}
@@ -89,6 +90,7 @@ end
 
     @testset "Downcast" begin
         x2 = recast(Float16, x)
+        zeros!(x2)
         @test x2 isa MoYeArray{Float16}
         @test x2.layout == @Layout (8, 3)
         @test x == recast(Float32, x2)

--- a/test/device/mmaop.jl
+++ b/test/device/mmaop.jl
@@ -17,7 +17,7 @@ if CUDA.functional()
         end
 
         op_to_intrinsic = Dict(MoYe.get_mma_ops())
-        for op in Base.subtypes(MMAOP)
+        for op in Main.subtypes(MMAOP)
             buf = IOBuffer()
             @device_code_llvm io = buf @cuda threads=32 kernel(op())
             asm = String(take!(copy(buf)))


### PR DESCRIPTION
Compute the length of `ViewEngine` is expensive.