### PR TITLE
fix(runtime): avoid pointer arithmetic with StaticInt

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -307,7 +307,7 @@ function _recast(::Type{NewType}, x::MoYeArray{OldType}) where {NewType, OldType
         shape_diff = map(-, flatten(shape(old_layout)), flatten(shape(new_layout)))
         extent_diff = map(*, shape_diff, flatten(stride(old_layout)))
         offset = _foldl((i,a)->i+min(a, Zero()), extent_diff, Zero())
-        return MoYeArray(recast(NewType, pointer(x) + offset * sizeof(OldType)), new_layout)
+        return MoYeArray(recast(NewType, pointer(x) + Int(offset) * sizeof(OldType)), new_layout)
     else
         return MoYeArray(recast(NewType, pointer(x)), new_layout)
     end

--- a/src/array.jl
+++ b/src/array.jl
@@ -307,7 +307,7 @@ function _recast(::Type{NewType}, x::MoYeArray{OldType}) where {NewType, OldType
         shape_diff = map(-, flatten(shape(old_layout)), flatten(shape(new_layout)))
         extent_diff = map(*, shape_diff, flatten(stride(old_layout)))
         offset = _foldl((i,a)->i+min(a, Zero()), extent_diff, Zero())
-        return MoYeArray(recast(NewType, pointer(x) + Int(offset) * sizeof(OldType)), new_layout)
+        return MoYeArray(recast(NewType, pointer(x) + offset * sizeof(OldType)), new_layout)
     else
         return MoYeArray(recast(NewType, pointer(x)), new_layout)
     end

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -13,3 +13,8 @@ Base.:(-)(x::LLVMPtr, ::StaticInt{N}) where {N} = x - N
 Base.:(-)(::StaticInt{N}, y::LLVMPtr) where {N} = y - N
 Base.:(+)(x::LLVMPtr, ::StaticInt{N}) where {N} = x + N
 Base.:(+)(::StaticInt{N}, y::LLVMPtr) where {N} = y + N
+
+Base.:(-)(x::Ptr, ::StaticInt{N}) where {N} = x - N
+Base.:(-)(::StaticInt{N}, y::Ptr) where {N} = y - N
+Base.:(+)(x::Ptr, ::StaticInt{N}) where {N} = x + N
+Base.:(+)(::StaticInt{N}, y::Ptr) where {N} = y + N


### PR DESCRIPTION
This PR fixes a MethodError that occurs when performing pointer arithmetic with a Static.StaticInt.